### PR TITLE
feat: speed up objects loops

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,9 @@ export default function diff(
 	newObj: Record<string, any> | any[]
 ): Difference[] {
 	let diffs: Difference[] = [];
-	for (const key in obj) {
+	const keys = Object.keys(obj);
+	for(let i = 0; i < keys.length; i++) {
+		const key = keys[i];
 		if (!(key in newObj)) {
 			diffs.push({
 				type: "REMOVE",
@@ -45,7 +47,9 @@ export default function diff(
 			});
 		}
 	}
-	for (const key in newObj) {
+	const nkeys = Object.keys(newObj);
+	for(let i = 0; i < nkeys.length; i++) {
+		const key = nkeys[i];
 		if (!(key in obj)) {
 			diffs.push({
 				type: "CREATE",


### PR DESCRIPTION
iterate object with `Object.keys` and a for loop on keys is faster than iterate using `for in`

https://github.com/simone-sanfratello/node-bench-iteration

https://simone-sanfratello.github.io/public/node-bench-iteration/index.html