### PR TITLE
MVP Implementation of a patch method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -75,3 +75,33 @@ export default function diff(
 	}
 	return diffs;
 }
+
+function patch(
+    obj: Record<string, any> | any[],
+    diffs: Difference[]
+): Record<string, any> | any[] {
+    var newObj = JSON.parse(JSON.stringify(obj)); // deep clone the source object
+
+    for (const diff of diffs) {
+        switch(diff.type) {
+            case "CREATE": // fall-through - equal to: case "CREATE" || "CHANGE"
+            case "CHANGE":
+                for (const path of diff.path) {
+                    newObj[path] = diff.value;
+                }
+                break;
+            case "REMOVE":
+                for (const path of diff.path) {
+                    if (Array.isArray(newObj)) {
+                        newObj = newObj.filter((e, i) => i !== path)
+                    } else {
+                        delete newObj[path];
+                    }
+                }
+                break;
+        }
+    }
+
+    return newObj;
+}
+

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ interface Options {
 }
 const t = true;
 const richTypes = { Date: t, RegExp: t, String: t, Number: t };
-export default function diff(
+export function diff(
 	obj: Record<string, any> | any[],
 	newObj: Record<string, any> | any[],
 	options: Partial<Options> = { cyclesFix: true },
@@ -76,7 +76,7 @@ export default function diff(
 	return diffs;
 }
 
-function patch(
+export function patch(
     obj: Record<string, any> | any[],
     diffs: Difference[]
 ): Record<string, any> | any[] {

--- a/index.ts
+++ b/index.ts
@@ -83,19 +83,24 @@ function patch(
     var newObj = JSON.parse(JSON.stringify(obj)); // deep clone the source object
 
     for (const diff of diffs) {
+        var currObj = newObj;
+        var diffPathLength = diff.path.length;
+        var lastPathElement = diff.path[diffPathLength - 1];
+        for (var i = 0; i < diffPathLength - 1; i++) {
+            currObj = currObj[diff.path[i]];
+        }
+
         switch(diff.type) {
             case "CREATE": // fall-through - equal to: case "CREATE" || "CHANGE"
             case "CHANGE":
-                for (const path of diff.path) {
-                    newObj[path] = diff.value;
-                }
+                currObj[lastPathElement] = diff.value;
                 break;
             case "REMOVE":
                 for (const path of diff.path) {
-                    if (Array.isArray(newObj)) {
-                        newObj = newObj.filter((e, i) => i !== path)
+                    if (Array.isArray(currObj[lastPathElement])) {
+                        currObj[lastPathElement] = currObj[lastPathElement].filter((e: any, i: number) => i !== path)
                     } else {
-                        delete newObj[path];
+                        delete currObj[lastPathElement];
                     }
                 }
                 break;
@@ -104,4 +109,3 @@ function patch(
 
     return newObj;
 }
-


### PR DESCRIPTION
This is a simple implementation for a patch method I came up with and it seems to work properly.

I think that you could speed up the deep clone (I just chose to do it via JSON for the sake of simplicity) and maybe there is a faster way for removing an array entry by a given key but I'm sure that this might be a good fundamental for a patch method.

This is an example that showcases the patch method.
```ts
import { diff, patch } from 'microdiff'

const obj = {"test5":  {"test": 4, "test5": true}, "test2": "test4"}
const obj2 = {"test5":  {"test": 5}}

var testDiff = diff(obj, obj2)
var testPatch = patch(obj, testDiff)
console.log(testDiff)
console.log(testPatch)

console.assert(JSON.stringify(obj2) === JSON.stringify(testPatch))
```