### PR TITLE
Improve typing of Difference interface

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,24 @@
-interface Difference {
-	type: "CREATE" | "REMOVE" | "CHANGE";
+interface DifferenceCreate {
+	type: "CREATE";
 	path: (string | number)[];
-	value?: any;
-	oldValue?: any;
+	value: any;
 }
+
+interface DifferenceRemove {
+	type: "REMOVE";
+	path: (string | number)[];
+	oldValue: any;
+}
+
+interface DifferenceChange {
+	type: "CHANGE";
+	path: (string | number)[];
+	value: any;
+	oldValue: any;
+}
+
+type Difference = DifferenceCreate | DifferenceRemove | DifferenceChange;
+
 interface Options {
 	cyclesFix: boolean;
 }


### PR DESCRIPTION
Create 3 specialized Difference interfaces which allows us to have some type-hinting when the value of the property `type` is tested :

```ts
const differences: Difference[] = diff({}, {});

for (const difference of differences) {
	switch (difference.type) {
		case "CREATE":
			console.log(difference); // type-hint : DifferenceCreate
			difference.oldValue; // Property 'oldValue' does not exist on type 'DifferenceCreate'
			break;
		case "REMOVE":
			console.log(difference); // type-hint : DifferenceRemove
			difference.value; // Property 'value' does not exist on type 'DifferenceRemove'
			break;
		case "CHANGE":
			console.log(difference); // type-hint : DifferenceChange
			difference.value // OK
			difference.oldValue // OK
			break;
	}
}
```
