### PR TITLE
feat: improve recursive diff performance

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,18 +69,20 @@ export default function diff(
 			(!options.cyclesFix || !_stack.includes(value))
 		) {
 			// Recurse into objects and arrays
-			diffs.push.apply(
-				diffs,
-				diff(
-					value,
-					newValue,
-					options,
-					options.cyclesFix ? _stack.concat([value]) : [],
-				).map((difference) => {
-					difference.path.unshift(path);
-					return difference;
-				}),
-			);
+			if (options.cyclesFix) {
+				_stack.push(value);
+			}
+
+			const subDiffs = diff(value, newValue, options, _stack);
+
+			if (options.cyclesFix) {
+				_stack.pop();
+			}
+
+			for (const subDiff of subDiffs) {
+				subDiff.path.unshift(path);
+				diffs.push(subDiff);
+			}
 		} else if (
 			!(
 				Object.is(value, newValue) /* treat nulls as equivalent */ ||


### PR DESCRIPTION
Benchmark | Mode | Master | recursive-perf | Δ
-- | -- | -- | -- | --
PandaCSS Config | no cycles | 12.06 µs | 10.62 µs | −11.9%
PandaCSS Config | cycles | 17.48 µs | 12.88 µs | −26.3%
Scalar/OpenAPI Doc | no cycles | 7.44 µs | 6.76 µs | −9.1%
Scalar/OpenAPI Doc | cycles | 10.80 µs | 8.14 µs | −24.6%
Vanilla Extract Theme | no cycles | 6.99 µs | 6.43 µs | −8.0%
Vanilla Extract Theme | cycles | 9.07 µs | 7.44 µs | −18.0%
Large Object (300 props) | no cycles | 14.01 µs | 13.62 µs | −2.8%
Large Object (300 props) | cycles | 13.84 µs | 13.76 µs | −0.6%
Large Diff (300 props) | no cycles | 9.74 µs | 9.42 µs | −3.3%
Large Diff (300 props) | cycles | 9.62 µs | 9.48 µs | −1.5%
Deeply Nested Object | no cycles | 144.1 µs | 120.1 µs | −16.7%
Deeply Nested Object | cycles | 180.9 µs | 131.4 µs | −27.3%
Small Object | no cycles | 65.81 ns | 67.78 ns | +3.0%
Small Object | cycles | 65.37 ns | 66.95 ns | +2.4%
